### PR TITLE
Skip `unprivileged_userns_clone` on SteamOS

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,17 @@ root_setup() {
 
 rootless_setup() {
     asroot=''
-    if [ "$(sysctl -n kernel.unprivileged_userns_clone >&2 || echo 1)" -ne 1 ]
+    if [ "$(lsb_release -is)" == "SteamOS" ]
+    then
+        uuccommand(){
+            sysctl -n kernel.unprivileged_userns_clone -e >&2 || echo 1
+        }
+    else
+        uuccommand(){
+            sysctl -n kernel.unprivileged_userns_clone >&2 || echo 1
+        }
+    fi
+    if [ "$(uuccommand)" -ne 1 ]
     then
         echo "WARNING: kernel.unprivileged_userns_clone not set to 1." >&2
         asroot="${asroot}sysctl kernel.unprivileged_userns_clone=1\n"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,18 +60,14 @@ rootless_setup() {
     asroot=''
     if [ "$(lsb_release -is)" == "SteamOS" ]
     then
-        uuccommand(){
-            sysctl -n kernel.unprivileged_userns_clone -e >&2 || echo 1
-        }
+        # SteamOS sets `unprivileged_userns_clone` to `1` by default, so skip this check...
+        :
     else
-        uuccommand(){
-            sysctl -n kernel.unprivileged_userns_clone >&2 || echo 1
-        }
-    fi
-    if [ "$(uuccommand)" -ne 1 ]
-    then
-        echo "WARNING: kernel.unprivileged_userns_clone not set to 1." >&2
-        asroot="${asroot}sysctl kernel.unprivileged_userns_clone=1\n"
+        if [ "$(sysctl -n kernel.unprivileged_userns_clone >&2 || echo 1)" -ne 1 ]
+        then
+            echo "WARNING: kernel.unprivileged_userns_clone not set to 1." >&2
+            asroot="${asroot}sysctl kernel.unprivileged_userns_clone=1\n"
+        fi
     fi
     for f in /etc/subuid /etc/subgid
     do


### PR DESCRIPTION
As mentioned in #1, SteamOS sets `unprivileged_userns_clone` to `1` by default, albeit in a non-configurable manner.

This PR aims to quieten the error seen by skipping this check on SteamOS.